### PR TITLE
Add `cardRevealed` subscription

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,14 @@
   // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
   "version": "0.2.0",
   "configurations": [
-
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Launch Server",
+      "cwd": "${workspaceRoot}/packages/server",
+      "runtimeArgs": ["-r", "ts-node/register"],
+      "args": ["${workspaceRoot}/packages/server/src/index.ts"]
+    },
     {
       "type": "node",
       "request": "launch",

--- a/packages/server/src/context/authenticate.test.ts
+++ b/packages/server/src/context/authenticate.test.ts
@@ -48,7 +48,7 @@ test("it throws an error if there is a header that does not match a user", t => 
 test("it assigns a new user if there is no header", t => {
   t.context.info.req.headers.authentication = "";
   const context = {
-    players: new DB()
+    players: new DB<Player>()
   };
 
   const resultingContext = authenticate(t.context.info, context);

--- a/packages/server/src/context/authenticate.ts
+++ b/packages/server/src/context/authenticate.ts
@@ -1,11 +1,25 @@
-import Player from "../types/Player";
 import { AuthenticationError } from "apollo-server";
+import Player, { PlayerContext } from "../types/Player";
+import { InitialSubscriptionContext } from "../subscription";
+
+type PreAuthenticationContext = PlayerContext & InitialSubscriptionContext;
 
 export type AuthenticatedContext = {
   currentPlayer: Player;
 };
-export default function authenticate({ req }, context): AuthenticatedContext {
-  const token = req.headers.authentication || "";
+
+export default function authenticate(
+  { req },
+  context: PreAuthenticationContext
+): AuthenticatedContext {
+  let token = "";
+
+  if (context.isWebsocketConnection && context.authentication) {
+    token = context.authentication;
+  } else if (req && req.headers && req.headers.authentication) {
+    token = req.headers.authentication;
+  }
+
   let currentPlayer = context.players.where({
     id: token
   });

--- a/packages/server/src/context/index.ts
+++ b/packages/server/src/context/index.ts
@@ -1,9 +1,16 @@
+import { get } from "lodash";
 import { context as Players } from "../types/Player";
 import { context as Games } from "../types/Game";
 import authentication from "./authenticate";
 
-type RequestInfo = object;
 type Context<T = {}> = { [P in keyof T]: T[P] };
+type RequestInfo = {
+  req?: object;
+  res?: object;
+  connection?: {
+    context?: Context;
+  };
+};
 type ContextCreator<T = {}> = (
   info: RequestInfo,
   context?: Context
@@ -25,10 +32,12 @@ type ContextCreator<T = {}> = (
 export function buildContext(
   ...contextFunctions: ContextCreator[]
 ): (RequestInfo) => Context {
-  return function(param: RequestInfo) {
+  return function(requestInfo: RequestInfo) {
+    const initialContext: Context = get(requestInfo, "connection.context", {});
+
     return contextFunctions.reduce((acc, fn) => {
-      return { ...acc, ...fn(param, acc) };
-    }, {});
+      return { ...acc, ...fn(requestInfo, acc) };
+    }, initialContext);
   };
 }
 

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -6,8 +6,11 @@ import * as Game from "./types/Game";
 import * as Mutation from "./types/Mutation";
 import * as Player from "./types/Player";
 import * as Query from "./types/Query";
+import * as Subscription from "./types/Subscription";
 import * as Team from "./types/Team";
+
 import context from "./context";
+import { onConnect } from "./subscription";
 
 const PORT = process.env["PORT"] || 5000;
 
@@ -18,9 +21,13 @@ const server = new ApolloServer({
     Mutation.typeDef,
     Player.typeDef,
     Query.typeDef,
+    Subscription.typeDef,
     Team.typeDef
   ],
   resolvers: merge(Game.resolvers, Card.resolvers, Player.resolvers),
+  subscriptions: {
+    onConnect
+  },
   context
 });
 

--- a/packages/server/src/subscription/index.ts
+++ b/packages/server/src/subscription/index.ts
@@ -1,0 +1,28 @@
+export type InitialSubscriptionContext = {
+  /**
+   * Added to the context when the WebSocket connects, to denote the source
+   * of the connection
+   */
+  isWebsocketConnection?: true;
+
+  /**
+   * If the connection came from a WebSocket, this header _might_ be provided
+   * on the request.
+   *
+   * For WebSocket connections, the regular `req` object does not exist
+   */
+  authentication?: string;
+};
+
+export type ConnectionParams = {
+  authentication?: string;
+};
+
+export function onConnect({
+  authentication
+}: ConnectionParams): InitialSubscriptionContext {
+  return {
+    authentication: authentication,
+    isWebsocketConnection: true
+  };
+}

--- a/packages/server/src/types/Subscription.ts
+++ b/packages/server/src/types/Subscription.ts
@@ -1,0 +1,13 @@
+import { gql } from "apollo-server";
+
+export const typeDef = gql`
+  type CardRevealedPayload {
+    card: Card!
+    index: Int!
+  }
+
+  type Subscription {
+    # Card stuff
+    cardRevealed(gameId: ID!): CardRevealedPayload!
+  }
+`;


### PR DESCRIPTION
This change allows a client to subscribe to events related to cards being revealed for a game.

The intention is that when a game is active, this subscribe will allow all players to receive information about cards revealed by the other players.

Before implementing the subscribe, I first allows the client to provide an authentication token for the WebSocket connection, the same way it should be provided for "regular" requests. This allows the `context.currentPlayer` to be available regardless of which transportation (HTTP or WebSocket) technology is being used to communicate.

With that in place, I built out a single simple subscription that is emitted whenever a card is revealed. These events are filtered by the subscribed `gameId` before being sent, so the user only gets events that are relevant to it. This is a nice level of abstraction that allows the emitter to send events freely and control who is getting the events in a different location.